### PR TITLE
Loading Screen

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 import orangeClockFunctions.displayBlockMoscowFees as orangeClock
 import orangeClockFunctions.displaySetupDialog as setupDialog
+import orangeClockFunctions.displayLoadingScreen as loadingScreen
 from phew import access_point, connect_to_wifi, is_connected_to_wifi, dns, server
 from phew.template import render_template
 import json
@@ -55,10 +56,17 @@ def setup_mode():
     ip = ap.ifconfig()[0]
     dns.run_catchall(ip)
 
-def application_mode():
+def application_mode(ip: str = ""):
+    """Function to start the main display application. A loading screen is first booted to be shown as the main display
+    loads.
+
+    :param ip: The IP of OrangeClock
+    """
     print("Entering application mode.")
     onboard_led = machine.Pin("LED", machine.Pin.OUT)
     orangeClock.setSecrets(wifi_credentials["ssid"], wifi_credentials["password"])
+    print("Loading...")
+    loadingScreen.main(ip)
     orangeClock.main()
 
     def app_index(request):
@@ -95,7 +103,7 @@ try:
             machine_reset()
 
         print(f"Connected to wifi, IP address {ip_address}")
-        application_mode()
+        application_mode(ip_address)
 
 except Exception:
     # Either no wifi configuration file found, or something went wrong, 

--- a/src/orangeClockFunctions/displayBlockMoscowFees.py
+++ b/src/orangeClockFunctions/displayBlockMoscowFees.py
@@ -114,7 +114,8 @@ def main():
     mempoolFees = ""
     i = 1
     connectWIFI()
-    displayInit()
+    # displayInit()
+    initial_boot = True  # Flag for tracking if loop is first
     while True:
         print("===============debug id=2===============")
         print("memory use: ", gc.mem_alloc() / 1024, "KiB")
@@ -174,6 +175,8 @@ def main():
         if wifi.isconnected():
             refresh(ssd, True)
             ssd.wait_until_ready()
+        if initial_boot:  # If first time booting...
+            displayInit()  # Init the display
         Label(
             wri_small,
             labelRow1,
@@ -263,8 +266,10 @@ def main():
         refresh(ssd, False)
         ssd.wait_until_ready()
         ssd.sleep()
+        initial_boot = False  # Turn init off for subsequent cycles
         if not issue:
             time.sleep(600)  # 600 normal
+            print("refreshing...")
         else:
             wifi.disconnect()
             print("===============debug id=3===============")

--- a/src/orangeClockFunctions/displayLoadingScreen.py
+++ b/src/orangeClockFunctions/displayLoadingScreen.py
@@ -1,0 +1,72 @@
+from gui.widgets.label import Label
+from gui.core.writer import Writer
+from gui.core.nanogui import refresh
+from color_setup import ssd
+
+import gui.fonts.libreFranklinSemiBold29 as Small
+import gui.fonts.orangeClockIcons25 as iconsSmall
+
+wri_small = Writer(ssd, Small, verbose=False)  # Small writing
+wri_iconsSmall = Writer(ssd, iconsSmall, verbose=False)  # Small icons
+
+rowMaxDisplay = 296
+labelRow1 = 5
+labelRow2 = 46
+labelRow3 = 85
+labelCol = 10
+
+
+def main(ip: str):
+    """The main function for displaying a wait screen as OrangeClock loads. It also displays the connected IP address,
+    so it can be seen if connection is actually successful.
+
+    :param ip: The IP address that orange clock is connected at
+    :type ip: str
+    """
+    txt_connected = ip
+    txt_please_wait1 = "Please wait while"
+    txt_please_wait2 = "OrangeClock loads..."
+
+    refresh(ssd, True)
+    ssd.wait_until_ready()
+    print("Loading screen...")
+    # == Row 1 ==
+    # Text
+    Label(
+        wri_small,
+        labelRow1,
+        int(labelCol + Writer.stringlen(wri_iconsSmall, "I") + 4),
+        txt_connected,
+    )
+
+    # Wifi icon
+    Label(
+        wri_iconsSmall,
+        labelRow1,
+        labelCol,
+        "I",
+    )
+
+    # == Row 2 ==
+    # Text
+    Label(
+        wri_small,
+        labelRow2,
+        labelCol,
+        txt_please_wait1,
+    )
+
+    # == Row 3 ==
+    # Text
+    Label(
+        wri_small,
+        labelRow3,
+        labelCol,
+        txt_please_wait2,
+    )
+
+    ssd.wait_until_ready()
+    refresh(ssd, False)
+    ssd.wait_until_ready()
+    print("sleep")
+    print("Load end")


### PR DESCRIPTION
**Proposed changes:**
- Add loading screen between setup and application displays
- Change order of screen init on application display

**Effect:**
Once `application_mode()` is called, `loadingScreen()` is called prior to `orangeClock.main()`, showing a new screen telling user the IP address OrangeClock is connected as (to show them connection was successful), and informing them that the main screen is loading.

In order to stop the display from being erased once `orangeClock.main()` is called, `displayInit()` has been moved to within the process loop of the main display. To prevent repeated initialisation, a flag has been added which tracks whether the main loop is the first occurrence (subsequent loops do not call the init). 

Feedback and changes welcome

M