### PR TITLE
Faster screen updates

### DIFF
--- a/src/color_setup.py
+++ b/src/color_setup.py
@@ -54,4 +54,3 @@ pdc = machine.Pin(DC_PIN, machine.Pin.OUT)
 gc.collect()  # Precaution before instantiating framebuf
 ssd = SSD(spi, pcs, pdc, prst, pbusy, landscape=True, asyn=False, full=True)  # Create a display instance ssd = SSD(spi, pcs, pdc, prst, pbusy, landscape=True, asyn=False, full=False) for partial refresh
 # ssdred = SSDred(spi, pcs, pdc, prst, pbusy, landscape=False)  # Cread a red display instance (just for B model)
-ssd.demo_mode = True


### PR DESCRIPTION
Specifying `demo = True` incurs a 2sec wait in [EPD](https://github.com/marc3linho/OrangeClock/blob/main/src/drivers/ePaper2in9.py#L276).

I have not seen any ill-effects from this change. Regular screen updates in each `main()` cycle render much quicker (presumably 2s quicker! Overall more like 0.5s) and just feels smoother.