### PR TITLE
In-place display updates

### DIFF
--- a/src/orangeClockFunctions/displayBlockMoscowFees.py
+++ b/src/orangeClockFunctions/displayBlockMoscowFees.py
@@ -207,100 +207,104 @@ def main():
             print("Fees: Handling run-time error:", err)
             debugConsoleOutput("5")
             issue = True
-        if wifi.isconnected():
-            refresh(ssd, True)
-            ssd.wait_until_ready()
-        Label(
-            wri_small,
-            labelRow1,
-            int(
-                (
-                    rowMaxDisplay
-                    - Writer.stringlen(wri_small, blockHeight)
-                    + Writer.stringlen(wri_iconsSmall, symbolRow1)
-                    + 4  # spacing
-                )
-                / 2
-            ),
-            blockHeight,
-        )
 
-        Label(
-            wri_iconsSmall,
-            labelRow1 + 2,  # center icon with text
-            int(
-                (
-                    rowMaxDisplay
-                    - Writer.stringlen(wri_iconsSmall, symbolRow1)
-                    - Writer.stringlen(wri_small, blockHeight)
-                    - 4  # spacing
-                )
-                / 2
+        labels = [
+            Label(
+                wri_small,
+                labelRow1,
+                int(
+                    (
+                        rowMaxDisplay
+                        - Writer.stringlen(wri_small, blockHeight)
+                        + Writer.stringlen(wri_iconsSmall, symbolRow1)
+                        + 4  # spacing
+                    )
+                    / 2
+                ),
+                blockHeight,
             ),
-            symbolRow1,
-        )
-        Label(
-            wri_large,
-            labelRow2,
-            int(
-                (
-                    rowMaxDisplay
-                    - Writer.stringlen(wri_large, textRow2)
-                    + Writer.stringlen(wri_iconsLarge, symbolRow2)
-                    + 2  # spacing
-                )
-                / 2
+            Label(
+                wri_iconsSmall,
+                labelRow1 + 2,  # center icon with text
+                int(
+                    (
+                        rowMaxDisplay
+                        - Writer.stringlen(wri_iconsSmall, symbolRow1)
+                        - Writer.stringlen(wri_small, blockHeight)
+                        - 4  # spacing
+                    )
+                    / 2
+                ),
+                symbolRow1,
             ),
-            textRow2,
-        )
-        Label(
-            wri_iconsLarge,
-            labelRow2,  # + 10 for centered satsymbol
-            int(
-                (
-                    rowMaxDisplay
-                    - Writer.stringlen(wri_iconsLarge, symbolRow2)
-                    - Writer.stringlen(wri_large, textRow2)
-                    - 2  # spacing
-                )
-                / 2
+            Label(
+                wri_large,
+                labelRow2,
+                int(
+                    (
+                        rowMaxDisplay
+                        - Writer.stringlen(wri_large, textRow2)
+                        + Writer.stringlen(wri_iconsLarge, symbolRow2)
+                        + 2  # spacing
+                    )
+                    / 2
+                ),
+                textRow2,
             ),
-            symbolRow2,
-        )
-        Label(
-            wri_small,
-            labelRow3,
-            int(
-                (
-                    rowMaxDisplay
-                    - Writer.stringlen(wri_small, mempoolFees)
-                    + Writer.stringlen(wri_iconsSmall, symbolRow3)
-                    + 4  # spacing
-                )
-                / 2
+            Label(
+                wri_iconsLarge,
+                labelRow2,  # + 10 for centered satsymbol
+                int(
+                    (
+                        rowMaxDisplay
+                        - Writer.stringlen(wri_iconsLarge, symbolRow2)
+                        - Writer.stringlen(wri_large, textRow2)
+                        - 2  # spacing
+                    )
+                    / 2
+                ),
+                symbolRow2,
             ),
-            mempoolFees,
-        )
-        Label(
-            wri_iconsSmall,
-            labelRow3 + 1,  # center icon with text
-            int(
-                (
-                    rowMaxDisplay
-                    - Writer.stringlen(wri_iconsSmall, symbolRow3)
-                    - Writer.stringlen(wri_small, mempoolFees)
-                    - 4  # spacing
-                )
-                / 2
+            Label(
+                wri_small,
+                labelRow3,
+                int(
+                    (
+                        rowMaxDisplay
+                        - Writer.stringlen(wri_small, mempoolFees)
+                        + Writer.stringlen(wri_iconsSmall, symbolRow3)
+                        + 4  # spacing
+                    )
+                    / 2
+                ),
+                mempoolFees,
             ),
-            symbolRow3,
-        )
+            Label(
+                wri_iconsSmall,
+                labelRow3 + 1,  # center icon with text
+                int(
+                    (
+                        rowMaxDisplay
+                        - Writer.stringlen(wri_iconsSmall, symbolRow3)
+                        - Writer.stringlen(wri_small, mempoolFees)
+                        - 4  # spacing
+                    )
+                    / 2
+                ),
+                symbolRow3,
+            )
+        ]
 
         refresh(ssd, False)
         ssd.wait_until_ready()
         ssd.sleep()
         if not issue:
             time.sleep(600)  # 600 normal
+
+            # Have the Labels write blanks into the framebuf to erase what they
+            # rendered in the previous cycle.
+            for label in labels:
+                label.value("")
         else:
             wifi.disconnect()
             debugConsoleOutput("6")
@@ -309,5 +313,3 @@ def main():
             gc.collect()
 
         i = i + 1
-        
-        


### PR DESCRIPTION
Omits the `refresh()` call that precedes each screen update loop so now there is no full-screen clear.

Retains the Labels in a list so that at the end of the sleep cycle (aka beginning of the next update loop) the Labels clear the framebuffer to erase the pixels that they had set in the previous update. This framebuf clear is just in memory; the upcoming update loop will write more changes into the framebuf before it is written to the display.

## Caveat
A consequence of not doing a full-screen clear is that there will be faint residual ghosting. Somewhat exaggerated in this pic; it's less visible to the naked eye.

![PXL_20231223_143249732 MP~2](https://github.com/marc3linho/OrangeClock/assets/934746/33335931-2083-4ea5-a0bf-356f82e7e151)

In dark mode (PR coming soonish) this ghosting is not an issue (it probably still occurs, but there are just hardly any "off" pixels and the perceived contrast is stronger so any ghosting is not noticeable).