### PR TITLE
exceptions raised to main are logged/printed

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,10 +1,12 @@
 import orangeClockFunctions.displayBlockMoscowFees as orangeClock
 import orangeClockFunctions.displaySetupDialog as setupDialog
-from phew import access_point, connect_to_wifi, is_connected_to_wifi, dns, server
+from phew import access_point, connect_to_wifi, is_connected_to_wifi, dns, server, logging
 from phew.template import render_template
 import json
 import machine
 import os
+import uio
+import usys
 import utime
 import _thread
 
@@ -96,9 +98,12 @@ try:
         print(f"Connected to wifi, IP address {ip_address}")
         application_mode()
 
-except Exception:
+except Exception as err:
     # Either no wifi configuration file found, or something went wrong, 
-    # so go into setup mode.
+    # so log exception, then go into setup mode.
+    tmp = uio.StringIO()
+    usys.print_exception(err, tmp)
+    logging.exception(f"> {tmp.getvalue().replace('\n','\\n')}")
     setup_mode()
     
  


### PR DESCRIPTION
Uses existing logging from phew, so that info is printed to the console AND logged as an exception.
Includes awkward hack to get traceback information within standard micropython.
logged message remains on one line of the log so that it can easily be cut/pasted into a python repl like:
`print('''<pasted_contents>''')`

ex)  For a new install where no "wifi.json" exists, the "log.txt" entry would look like:
```
2024-01-12 13:21:41 [exception / 106kB] > Traceback (most recent call last):\n  File "main.py", line 83, in <module>\nOSError: [Errno 2] ENOENT\n
```
... directing curiosity towards the `os.stat(WIFI_FILE)` line of code.