### PR TITLE
external data separated into datastore

### DIFF
--- a/src/orangeClockFunctions/datastore.py
+++ b/src/orangeClockFunctions/datastore.py
@@ -102,14 +102,18 @@ def list_stale():
     return [k for k,v in _extdata.items() if v.stale]
 
 def get_height():
-    return int(_extdata["height"].data)
+    if "height" in _extdata:
+        return int(_extdata["height"].data)
 
 def get_price(key): # USD, EUR
-    return _extdata["prices"].data[key]
+    if "prices" in _extdata:
+        return _extdata["prices"].data[key]
 
 def get_fees_dict():
-    return _extdata["fees"].data
+    if "fees" in _extdata:
+        return _extdata["fees"].data
 
 def get_nostr_zap_count():
-    pubkey = [x for x in _extdata["zaps"].data['stats'].keys()][0]
-    return _extdata["zaps"].data["stats"][pubkey]["zaps_received"]["count"]
+    if "zaps" in _extdata:
+        pubkey = [x for x in _extdata["zaps"].data['stats'].keys()][0]
+        return _extdata["zaps"].data["stats"][pubkey]["zaps_received"]["count"]

--- a/src/orangeClockFunctions/datastore.py
+++ b/src/orangeClockFunctions/datastore.py
@@ -32,7 +32,7 @@ class ExternalData:
                 self.updated = now
                 self.stale = False
             else:
-                print("status_code {}: requests.get({})".format(status_code, self.url))
+                print("status_code {}: requests.get({})".format(response.status_code, self.url))
                 data = self.data
                 self.stale = True
                 answer = False

--- a/src/orangeClockFunctions/datastore.py
+++ b/src/orangeClockFunctions/datastore.py
@@ -50,7 +50,7 @@ class ExternalData:
 #
 # _extdata is a singleton dict holding ExternalData instances -- used internally
 #
-_extdata = None
+_extdata = {}
 
 
 #
@@ -58,12 +58,14 @@ _extdata = None
 #
 
 def initialize():
-    global _extdata
-    _extdata = {
+    keys = [x for x in _extdata.keys()]
+    for key in keys:
+        del _extdata[key]
+    _extdata.update({
         "prices": ExternalData("https://mempool.space/api/v1/prices", 300),
         "fees": ExternalData("https://mempool.space/api/v1/fees/recommended", 120),
         "height": ExternalData("https://mempool.space/api/blocks/tip/height", 180, json=False),
-    }
+    })
 
 def set_nostr_pubkey(npub):
     _extdata['zaps'] = ExternalData("https://api.nostr.band/v0/stats/profile/"+npub, 300)

--- a/src/orangeClockFunctions/datastore.py
+++ b/src/orangeClockFunctions/datastore.py
@@ -8,6 +8,7 @@ class ExternalData:
         self.ttl = ttl
         self.json = json
         self.updated = None
+        self.stale = None
         self.data = None
         self.refresh()
 
@@ -29,13 +30,16 @@ class ExternalData:
                 else:
                     data = response.text
                 self.updated = now
+                self.stale = False
             else:
                 print("status_code {}: requests.get({})".format(status_code, self.url))
                 data = self.data
+                self.stale = True
                 answer = False
         except Exception as err:
             print("Exception {}: requests.get({})".format(err, self.url))
             data = self.data
+            self.stale = True
             answer = False
         finally:
             try: response.close()
@@ -93,6 +97,9 @@ def refresh(raise_on_failure=False):
 #
 # functions for getting "raw" values from the _extdata singleton
 #
+
+def list_stale():
+    return [k for k,v in _extdata.items() if v.stale]
 
 def get_height():
     return int(_extdata["height"].data)

--- a/src/orangeClockFunctions/datastore.py
+++ b/src/orangeClockFunctions/datastore.py
@@ -1,0 +1,106 @@
+import time
+import requests
+
+
+class ExternalData:
+    def __init__(self, url, ttl=300, json=True):
+        self.url = url
+        self.ttl = ttl
+        self.json = json
+        self.updated = None
+        self.data = None
+        self.refresh()
+
+    def __str__(self):
+        return 'ExternalData("{}")'.format(self.url)
+
+    def refresh(self):
+        now = time.time()
+        answer = None
+
+        if self.updated and self.updated + self.ttl > now:
+            return answer
+
+        try:
+            response = requests.get(self.url)
+            if response.status_code == 200:
+                if self.json:
+                    data = response.json()
+                else:
+                    data = response.text
+                self.updated = now
+            else:
+                print("status_code {}: requests.get({})".format(status_code, self.url))
+                data = self.data
+                answer = False
+        except Exception as err:
+            print("Exception {}: requests.get({})".format(err, self.url))
+            data = self.data
+            answer = False
+        finally:
+            try: response.close()
+            except Exception: pass
+
+        if data != self.data:
+            self.data = data
+            answer = True
+
+        return answer
+
+#
+# _extdata is a singleton dict holding ExternalData instances -- used internally
+#
+_extdata = None
+
+
+#
+# functions for updating the _extdata singleton
+#
+
+def initialize():
+    global _extdata
+    _extdata = {
+        "prices": ExternalData("https://mempool.space/api/v1/prices", 300),
+        "fees": ExternalData("https://mempool.space/api/v1/fees/recommended", 120),
+        "height": ExternalData("https://mempool.space/api/blocks/tip/height", 180, json=False),
+    }
+
+def set_nostr_pubkey(npub):
+    _extdata['zaps'] = ExternalData("https://api.nostr.band/v0/stats/profile/"+npub, 300)
+
+def refresh(raise_on_failure=False):
+    refreshed = []
+    failures = []
+    for key, datum in _extdata.items():
+        result = datum.refresh()
+        if result == False:
+            failures.append(key)
+        elif result == True:
+            refreshed.append(key)
+        else:
+            pass # no change
+    if failures:
+        msg = "datastore.refresh() had failures: {}".format(",".join(failures))
+        if raise_on_failure:
+            raise Exception(msg)
+        else:
+            print(msg)
+    return refreshed
+
+
+#
+# functions for getting "raw" values from the _extdata singleton
+#
+
+def get_height():
+    return int(_extdata["height"].data)
+
+def get_price(key): # USD, EUR
+    return _extdata["prices"].data[key]
+
+def get_fees_dict():
+    return _extdata["fees"].data
+
+def get_nostr_zap_count():
+    pubkey = [x for x in _extdata["zaps"].data['stats'].keys()][0]
+    return _extdata["zaps"].data["stats"][pubkey]["zaps_received"]["count"]

--- a/src/orangeClockFunctions/displayBlockMoscowFees.py
+++ b/src/orangeClockFunctions/displayBlockMoscowFees.py
@@ -25,6 +25,7 @@ labelRow3 = 98
 symbolRow1 = "A"
 symbolRow2 = "L"
 symbolRow3 = "F"
+warningIcon = "R"
 secretsSSID = ""
 secretsPASSWORD = ""
 dispVersion1 = "bh"  #bh = block height / hal = halving countdown / zap = Nostr zap counter
@@ -151,6 +152,8 @@ def main():
             refresh(ssd, True)
             time.sleep(5)
         try:
+            # alternatively: can avoid using raise_on_falure paramater
+            # and instead call datastore.list_stale() for a list of stale data.
             new_data = datastore.refresh(raise_on_failure=True)
             if new_data:
                 print("datastore.refresh() had updates: {}".format(",".join(new_data)))
@@ -206,7 +209,11 @@ def main():
             debugConsoleOutput("5")
             issue = True
 
-        labels = [
+        labels = []
+        if issue:
+            # warning-icon in upper-left corner to indicate error(s)
+            labels.append(Label(wri_iconsSmall, 0, 0, warningIcon))
+        labels += [
             Label(
                 wri_small,
                 labelRow1,


### PR DESCRIPTION
This is meant to compartmentalize requesting of external data from the main application loop.

* treats datastore module in an object-oriented-ish fashion.  Import datastore, set it up w/ datastore.initialize(), then use its exposed getter functions like they were methods which quickly return with data that has already been retrieved.  use datastore.refresh() occasionally (which will request fresh data, or return quickly if data is somewhat current).

* no longer prints (error) to the e-paper display, instead leaves old data viewable.  gives hints of failure in the console log if watching the pico repl.  As of commit #e3757cd, also adds small warning-icon in upper-left corner of screen to indicate errors.

* debug function which prints memory usage now does a single gc.collect() and shows what had been used -- only once per application loop... only available if watching the pico repl.