### PR TITLE
adds/uses orangeClockFunctions.logging.log_exception()

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 import orangeClockFunctions.displayBlockMoscowFees as orangeClock
 import orangeClockFunctions.displaySetupDialog as setupDialog
-from phew import access_point, connect_to_wifi, is_connected_to_wifi, dns, server, logging
+from orangeClockFunctions.logging import log_exception
+from phew import access_point, connect_to_wifi, is_connected_to_wifi, dns, server
 from phew.template import render_template
 import json
 import machine
@@ -101,9 +102,7 @@ try:
 except Exception as err:
     # Either no wifi configuration file found, or something went wrong, 
     # so log exception, then go into setup mode.
-    tmp = uio.StringIO()
-    usys.print_exception(err, tmp)
-    logging.exception(f"> {tmp.getvalue().replace('\n','\\n')}")
+    log_exception(err)
     setup_mode()
     
  

--- a/src/orangeClockFunctions/displayBlockMoscowFees.py
+++ b/src/orangeClockFunctions/displayBlockMoscowFees.py
@@ -2,6 +2,7 @@ from color_setup import ssd
 from gui.core.writer import Writer
 from gui.core.nanogui import refresh
 from gui.widgets.label import Label
+from orangeClockFunctions.logging import log_exception
 
 import network
 import time
@@ -178,6 +179,7 @@ def main():
                 symbolRow1 = "A"
                 blockHeight = getLastBlock()    
         except Exception as err:
+            log_exception(err)
             blockHeight = "connection error"
             symbolRow1 = ""
             print("Block: Handling run-time error:", err)
@@ -200,6 +202,7 @@ def main():
                 symbolRow2 = "L"
                 textRow2 = getMoscowTime()        
         except Exception as err:
+            log_exception(err)
             textRow2 = "error"
             symbolRow2 = ""
             print("Moscow: Handling run-time error:", err)
@@ -209,6 +212,7 @@ def main():
             symbolRow3 = "F"
             mempoolFees = getMempoolFeesString()
         except Exception as err:
+            log_exception(err)
             mempoolFees = "connection error"
             symbolRow3 = ""
             print("Fees: Handling run-time error:", err)

--- a/src/orangeClockFunctions/logging.py
+++ b/src/orangeClockFunctions/logging.py
@@ -1,0 +1,10 @@
+import uio
+import usys
+from phew import logging
+
+def log_exception(exception):
+    tmp_string = uio.StringIO()
+    usys.print_exception(exception, tmp_string)
+    logging.exception("> {}".format(
+        tmp_string.getvalue().replace("\n", "\\n")
+    ))


### PR DESCRIPTION
This pr adds a new orangeClockFunctions.logging module with a single log_exception() function so that try/except blocks which catch an error can log it in the existing phew.log.  The advantage is to be able to "ignore"/hide exceptions and errors that might be seen on the display while better diagnosing problems after-the-fact.

`rshell cat /pyboard/log.txt` (or grabbing log.txt from the pico filesystem's root folder) will show an entry like:

```
2024-03-25 10:57:54 [exception /  97kB] > Traceback (most recent call last):\n  File "orangeClockFunctions/displayBlockMoscowFees.py", line 220, in main\n  File "orangeClockFunctions/displayBlockMoscowFees.py", line 130, in getDifficultyDisplay\nNameError: name 'boom' isn't defined\n
2024-04-02 07:43:50 [exception /  70kB] > Traceback (most recent call last):\n  File "orangeClockFunctions/datastore.py", line 27, in refresh\n  File "requests/__init__.py", line 180, in get\n  File "requests/__init__.py", line 130, in request\nValueError: HTTP error: BadStatusLine:\n[]\n
2024-04-03 01:07:04 [exception /  84kB] > Traceback (most recent call last):\n  File "orangeClockFunctions/datastore.py", line 27, in refresh\n  File "requests/__init__.py", line 180, in get\n  File "requests/__init__.py", line 93, in request\nOSError: (-29312, 'MBEDTLS_ERR_SSL_CONN_EOF')\n
2024-04-20 05:31:14 [exception / 101kB] > Traceback (most recent call last):\n  File "orangeClockFunctions/displayBlockMoscowFees.py", line 211, in main\n  File "orangeClockFunctions/displayBlockMoscowFees.py", line 100, in getPriceDisplay\n  File "orangeClockFunctions/datastore.py", line 114, in get_price\nTypeError: 'NoneType' object isn't subscriptable\n
2024-04-20 05:31:14 [exception / 102kB] > Traceback (most recent call last):\n  File "orangeClockFunctions/displayBlockMoscowFees.py", line 236, in main\n  File "orangeClockFunctions/displayBlockMoscowFees.py", line 112, in getMempoolFeesString\nTypeError: 'NoneType' object isn't subscriptable\n
2024-04-20 07:49:43 [exception / 103kB] > Traceback (most recent call last):\n  File "orangeClockFunctions/datastore.py", line 27, in refresh\n  File "requests/__init__.py", line 180, in get\n  File "requests/__init__.py", line 91, in request\nOSError: [Errno 103] ECONNABORTED\n
2024-04-20 08:44:55 [exception /  96kB] > Traceback (most recent call last):\n  File "orangeClockFunctions/datastore.py", line 27, in refresh\n  File "requests/__init__.py", line 180, in get\n  File "requests/__init__.py", line 93, in request\nOSError: [Errno 104] ECONNRESET\n
```
...note: above samples have been gathered and appended over time -- over a few different branches, as an attempt to share exceptions i've seen -- that others may have seen too.