### PR TITLE
Compartmentalized compositors module for E-Paper display

### DIFF
--- a/src/orangeClockFunctions/compositors.py
+++ b/src/orangeClockFunctions/compositors.py
@@ -3,7 +3,7 @@ from gui.widgets.label import Label
 
 import gui.fonts.orangeClockIcons25 as iconsSmall
 import gui.fonts.orangeClockIcons35 as iconsLarge
-import gui.fonts.libreFranklinBold56 as large
+import gui.fonts.libreFranklinBold50 as large
 import gui.fonts.libreFranklinSemiBold29 as small
 
 
@@ -26,13 +26,20 @@ def _setup(ssd):
     wri_small = Writer(ssd, small, verbose=False)
 
 
+def center_x_offset(screen_width, text_width):
+    x_offset = None
+    if text_width <= screen_width:
+        x_offset = (screen_width - text_width) // 2
+    return x_offset
+
 # compose three horizontally-centered rows, each having text + icon
-def composeClock(ssd, first, second, third):
+def composeClock(ssd, first, second, third, show_warning=False):
     """
-    pass: ssd, first, second, and third 
+    pass: ssd, first, second, and third
     where ssd is the display instance and first, second, third are
     tuples of (text, icon), where text and icon are the 
     text string and icon char to be rendered.
+    optionally: pass show_warning to display a warning icon (ie: stale data)
 
     returns list of Labels
     """
@@ -45,32 +52,45 @@ def composeClock(ssd, first, second, third):
     text_writers = (wri_small, wri_large, wri_small)
 
     # text and icon vertical position y-offsets for row1, row2, and row3
-    text_y_offsets = (5, 42, 98) 
-    icon_y_offsets = (7, 47, 99) 
+    text_y_offsets = (5, 44, 98)
+    icon_y_offsets = (7, 49, 99)
 
     # spacing between text and icon for row1, row2, and row3
-    spacings = (4, 2, 4)
+    spacings = (4, 0, 4)
 
     labels = []
+
+    # if show_warning: lay it down before others layers.
+    if show_warning:
+        labels.append(Label(icon_writers[0], 0, 0, "R"))
+
     for i, (text, icon) in enumerate([first, second, third]):
         icon_width = icon_writers[i].stringlen(icon)
         text_width = text_writers[i].stringlen(text)
 
-        # write the text
-        labels.append(Label(
-            text_writers[i],
-            text_y_offsets[i],
-            (ssd.width - text_width + icon_width + spacings[i]) // 2,
-            text
-        ))
-
         # write the icon
-        labels.append(Label(
-            icon_writers[i],
-            icon_y_offsets[i],
-            (ssd.width - text_width - icon_width - spacings[i]) // 2,
-            icon
-        ))
+        x_offset = center_x_offset(ssd.width, icon_width + spacings[i] + text_width)
+        if x_offset is not None:
+            labels.append(
+                Label(icon_writers[i], icon_y_offsets[i], x_offset, icon)
+            )
+        else:
+            print(f"icon would be offscreen: {icon}")
+
+        # write the text
+        if x_offset is not None:
+            x_offset = x_offset + icon_width + spacings[i]
+        else:
+            x_offset = center_x_offset(ssd.width, text_width)
+            while x_offset is None and len(text):
+                text = text[:-1]
+                text_width = text_writers[i].stringlen(text + "...")
+                x_offset = center_x_offset(ssd.width, text_width)
+                if x_offset is not None:
+                    text += "..."
+        labels.append(
+            Label(text_writers[i], text_y_offsets[i], x_offset, text)
+        )
 
     return labels
 
@@ -94,8 +114,8 @@ def composeSetup(ssd, first, second, third):
     text_writer = wri_small
 
     # text and icon vertical position y-offsets for row1, row2, and row3
-    text_y_offsets = (5, 46, 85) 
-    icon_y_offsets = (7, 46, 86) 
+    text_y_offsets = (5, 49, 85)
+    icon_y_offsets = (7, 49, 86)
 
     x_offset = 10 
     spacing = 4

--- a/src/orangeClockFunctions/compositors.py
+++ b/src/orangeClockFunctions/compositors.py
@@ -53,7 +53,7 @@ def composeClock(ssd, first, second, third, show_warning=False):
 
     # text and icon vertical position y-offsets for row1, row2, and row3
     text_y_offsets = (5, 44, 98)
-    icon_y_offsets = (7, 49, 99)
+    icon_y_offsets = (7, 44, 99)
 
     # spacing between text and icon for row1, row2, and row3
     spacings = (4, 0, 4)

--- a/src/orangeClockFunctions/compositors.py
+++ b/src/orangeClockFunctions/compositors.py
@@ -1,0 +1,123 @@
+from gui.core.writer import Writer
+from gui.widgets.label import Label
+
+import gui.fonts.orangeClockIcons25 as iconsSmall
+import gui.fonts.orangeClockIcons35 as iconsLarge
+import gui.fonts.libreFranklinBold56 as large
+import gui.fonts.libreFranklinSemiBold29 as small
+
+
+# use _setup with an ssd instance to setup writers
+wri_iconsLarge = None
+wri_iconsSmall = None
+wri_large = None
+wri_small = None
+def _setup(ssd):
+    global wri_iconsLarge
+    wri_iconsLarge = Writer(ssd, iconsLarge, verbose=False)
+
+    global wri_iconsSmall
+    wri_iconsSmall = Writer(ssd, iconsSmall, verbose=False)
+
+    global wri_large
+    wri_large = Writer(ssd, large, verbose=False)
+
+    global wri_small
+    wri_small = Writer(ssd, small, verbose=False)
+
+
+# compose three horizontally-centered rows, each having text + icon
+def composeClock(ssd, first, second, third):
+    """
+    pass: ssd, first, second, and third 
+    where ssd is the display instance and first, second, third are
+    tuples of (text, icon), where text and icon are the 
+    text string and icon char to be rendered.
+
+    returns list of Labels
+    """
+    # setup the writers if not already done
+    if None in (wri_iconsLarge, wri_iconsSmall, wri_large, wri_small):
+        _setup(ssd)
+
+    # text and icon writers for row1, row2, row3
+    icon_writers = (wri_iconsSmall, wri_iconsLarge, wri_iconsSmall)
+    text_writers = (wri_small, wri_large, wri_small)
+
+    # text and icon vertical position y-offsets for row1, row2, and row3
+    text_y_offsets = (5, 42, 98) 
+    icon_y_offsets = (7, 47, 99) 
+
+    # spacing between text and icon for row1, row2, and row3
+    spacings = (4, 2, 4)
+
+    labels = []
+    for i, (text, icon) in enumerate([first, second, third]):
+        icon_width = icon_writers[i].stringlen(icon)
+        text_width = text_writers[i].stringlen(text)
+
+        # write the text
+        labels.append(Label(
+            text_writers[i],
+            text_y_offsets[i],
+            (ssd.width - text_width + icon_width + spacings[i]) // 2,
+            text
+        ))
+
+        # write the icon
+        labels.append(Label(
+            icon_writers[i],
+            icon_y_offsets[i],
+            (ssd.width - text_width - icon_width - spacings[i]) // 2,
+            icon
+        ))
+
+    return labels
+
+
+# compose three left-justified rows, each having text + icon
+def composeSetup(ssd, first, second, third):
+    """
+    pass: ssd, first, second, and third 
+    where ssd is the display instance and first, second, third are
+    tuples of (text, icon), where text and icon are the 
+    text string and icon char to be rendered.
+
+    returns list of Labels
+    """
+    # setup the writers if not already done
+    if None in (wri_iconsLarge, wri_iconsSmall, wri_large, wri_small):
+        _setup(ssd)
+
+    # text and icon writers for row1, row2, row3
+    icon_writer = wri_iconsSmall
+    text_writer = wri_small
+
+    # text and icon vertical position y-offsets for row1, row2, and row3
+    text_y_offsets = (5, 46, 85) 
+    icon_y_offsets = (7, 46, 86) 
+
+    x_offset = 10 
+    spacing = 4
+
+    labels = []
+    for i, (text, icon) in enumerate([first, second, third]):
+        icon_width = icon_writer.stringlen(icon)
+
+        # write the text
+        labels.append(Label(
+            text_writer,
+            text_y_offsets[i],
+            x_offset + icon_width + spacing,
+            text
+        ))
+
+        # write the icon
+        labels.append(Label(
+            icon_writer,
+            icon_y_offsets[i],
+            x_offset,
+            icon
+        ))
+
+    return labels

--- a/src/orangeClockFunctions/displayBlockMoscowFees.py
+++ b/src/orangeClockFunctions/displayBlockMoscowFees.py
@@ -1,7 +1,6 @@
 from color_setup import ssd
-from gui.core.writer import Writer
 from gui.core.nanogui import refresh
-from gui.widgets.label import Label
+from orangeClockFunctions.compositors import composeClock
 
 import network
 import time
@@ -14,15 +13,6 @@ import gui.fonts.libreFranklinSemiBold29 as small
 import gc
 import math
 
-wri_iconsLarge = Writer(ssd, iconsLarge, verbose=False)
-wri_iconsSmall = Writer(ssd, iconsSmall, verbose=False)
-wri_large = Writer(ssd, large, verbose=False)
-wri_small = Writer(ssd, small, verbose=False)
-
-rowMaxDisplay = 296
-labelRow1 = 5
-labelRow2 = 44
-labelRow3 = 98
 symbolRow1 = "A"
 symbolRow2 = "L"
 symbolRow3 = "F"
@@ -215,92 +205,12 @@ def main():
             debugConsoleOutput("5")
             issue = True
 
-        labels = [
-            Label(
-                wri_small,
-                labelRow1,
-                int(
-                    (
-                        rowMaxDisplay
-                        - Writer.stringlen(wri_small, blockHeight)
-                        + Writer.stringlen(wri_iconsSmall, symbolRow1)
-                        + 4  # spacing
-                    )
-                    / 2
-                ),
-                blockHeight,
-            ),
-            Label(
-                wri_iconsSmall,
-                labelRow1 + 2,  # center icon with text
-                int(
-                    (
-                        rowMaxDisplay
-                        - Writer.stringlen(wri_iconsSmall, symbolRow1)
-                        - Writer.stringlen(wri_small, blockHeight)
-                        - 4  # spacing
-                    )
-                    / 2
-                ),
-                symbolRow1,
-            ),
-            Label(
-                wri_large,
-                labelRow2,
-                int(
-                    (
-                        rowMaxDisplay
-                        - Writer.stringlen(wri_large, textRow2)
-                        + Writer.stringlen(wri_iconsLarge, symbolRow2)
-                        # + 2  # spacing
-                    )
-                    / 2
-                ),
-                textRow2,
-            ),
-            Label(
-                wri_iconsLarge,
-                labelRow2,  # + 10 for centered satsymbol
-                int(
-                    (
-                        rowMaxDisplay
-                        - Writer.stringlen(wri_iconsLarge, symbolRow2)
-                        - Writer.stringlen(wri_large, textRow2)
-                        # - 2  # spacing
-                    )
-                    / 2
-                ),
-                symbolRow2,
-            ),
-            Label(
-                wri_small,
-                labelRow3,
-                int(
-                    (
-                        rowMaxDisplay
-                        - Writer.stringlen(wri_small, mempoolFees)
-                        + Writer.stringlen(wri_iconsSmall, symbolRow3)
-                        + 4  # spacing
-                    )
-                    / 2
-                ),
-                mempoolFees,
-            ),
-            Label(
-                wri_iconsSmall,
-                labelRow3 + 1,  # center icon with text
-                int(
-                    (
-                        rowMaxDisplay
-                        - Writer.stringlen(wri_iconsSmall, symbolRow3)
-                        - Writer.stringlen(wri_small, mempoolFees)
-                        - 4  # spacing
-                    )
-                    / 2
-                ),
-                symbolRow3,
-            )
-        ]
+        labels = composeClock(
+            ssd,
+            (blockHeight, symbolRow1),
+            (textRow2, symbolRow2),
+            (mempoolFees, symbolRow3)
+        )
 
         refresh(ssd, False)
         ssd.wait_until_ready()

--- a/src/orangeClockFunctions/displaySetupDialog.py
+++ b/src/orangeClockFunctions/displaySetupDialog.py
@@ -1,78 +1,23 @@
 from color_setup import ssd
-from gui.core.writer import Writer
 from gui.core.nanogui import refresh
-from gui.widgets.label import Label
+from orangeClockFunctions.compositors import composeSetup
 
 import time
-import gui.fonts.orangeClockIcons25 as iconsSmall
-import gui.fonts.libreFranklinBold50 as large
-import gui.fonts.libreFranklinSemiBold29 as small
-
-
-wri_iconsSmall = Writer(ssd, iconsSmall, verbose=False)
-wri_large = Writer(ssd, large, verbose=False)
-wri_small = Writer(ssd, small, verbose=False)
-
-
-labelRow1 = 5
-labelRow2 = 49
-labelRow3 = 85
-labelCol = 10
-
-displayLength = 296
-displayHeight = 128
 setupTxt = "Setup:" 
 wifiTxt = "OrangeClockWifi"  
 URITxt = "URI: orange.clock" 
 
-
 def main():
     refresh(ssd, True)
     ssd.wait_until_ready()
-    # time.sleep(10)
-    Label(
-        wri_small,
-        labelRow1,
-        int(labelCol + Writer.stringlen(wri_iconsSmall, "N") + 4),
-        setupTxt,
+
+    composeSetup(
+        ssd,
+        (setupTxt, "J"),
+        (wifiTxt, "L"),
+        (URITxt, "D")
     )
 
-    Label(
-        wri_iconsSmall,
-        labelRow1 + 2,
-        labelCol,
-        "N",
-    )
-    
-    Label(
-        wri_small,
-        labelRow2,
-        int(labelCol + Writer.stringlen(wri_iconsSmall, "O") + 4),
-        wifiTxt,
-    )
-    
-    Label(
-        wri_iconsSmall,
-        labelRow2,
-        labelCol,
-        "O",
-    )
-    
-    Label(
-        wri_small,
-        labelRow3,
-        int(labelCol + Writer.stringlen(wri_iconsSmall, "G") + 4),
-        URITxt,
-    )
-    
-    Label(
-        wri_iconsSmall,
-        labelRow3 + 1,
-        labelCol,
-        "G",
-    )
-
-    ssd.wait_until_ready()
     refresh(ssd, False)
     ssd.wait_until_ready()
     ssd.sleep()


### PR DESCRIPTION
DRAFT

This pr compartmentalizes "drawing to the e-paper screen" apart from existing orangeClockFunctions modules.

First and foremost, if this pr does NOT make editing easier for @easyuxd... then it has no value.

Otherwise, I'd argue that this pr has benefits of:
* a single place for "how" content is displayed to the e-paper screen (but not "what" content is displayed)
* programmability to ease editing of the lengthy multi-line "labels" variable
* ability to truncate icon/text which might result in screen overruns (an uncaught exception)
* ability to display a warning icon in upper left (eventually) if it is known that errors occurred gathering data