### PR TITLE
Logging and datastore -- and fees_overrun_display_fix

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 import orangeClockFunctions.displayBlockMoscowFees as orangeClock
 import orangeClockFunctions.displaySetupDialog as setupDialog
-from phew import access_point, connect_to_wifi, is_connected_to_wifi, dns, server, logging
+from orangeClockFunctions.logging import log_exception
+from phew import access_point, connect_to_wifi, is_connected_to_wifi, dns, server
 from phew.template import render_template
 import json
 import machine
@@ -101,9 +102,7 @@ try:
 except Exception as err:
     # Either no wifi configuration file found, or something went wrong, 
     # so log exception, then go into setup mode.
-    tmp = uio.StringIO()
-    usys.print_exception(err, tmp)
-    logging.exception(f"> {tmp.getvalue().replace('\n','\\n')}")
+    log_exception(err)
     setup_mode()
     
  

--- a/src/orangeClockFunctions/datastore.py
+++ b/src/orangeClockFunctions/datastore.py
@@ -1,0 +1,121 @@
+import time
+import requests
+from orangeClockFunctions.logging import log_exception
+
+
+class ExternalData:
+    def __init__(self, url, ttl=300, json=True):
+        self.url = url
+        self.ttl = ttl
+        self.json = json
+        self.updated = None
+        self.stale = None
+        self.data = None
+        self.refresh()
+
+    def __str__(self):
+        return 'ExternalData("{}")'.format(self.url)
+
+    def refresh(self):
+        now = time.time()
+        answer = None
+
+        if self.updated and self.updated + self.ttl > now:
+            return answer
+
+        try:
+            response = requests.get(self.url)
+            if response.status_code == 200:
+                if self.json:
+                    data = response.json()
+                else:
+                    data = response.text
+                self.updated = now
+                self.stale = False
+            else:
+                print("status_code {}: requests.get({})".format(response.status_code, self.url))
+                data = self.data
+                self.stale = True
+                answer = False
+        except Exception as err:
+            log_exception(err)
+            print("Exception {}: requests.get({})".format(err, self.url))
+            data = self.data
+            self.stale = True
+            answer = False
+        finally:
+            try: response.close()
+            except Exception: pass
+
+        if data != self.data:
+            self.data = data
+            answer = True
+
+        return answer
+
+#
+# _extdata is a singleton dict holding ExternalData instances -- used internally
+#
+_extdata = {}
+
+
+#
+# functions for updating the _extdata singleton
+#
+
+def initialize():
+    keys = [x for x in _extdata.keys()]
+    for key in keys:
+        del _extdata[key]
+    _extdata.update({
+        "prices": ExternalData("https://mempool.space/api/v1/prices", 300),
+        "fees": ExternalData("https://mempool.space/api/v1/fees/recommended", 120),
+        "height": ExternalData("https://mempool.space/api/blocks/tip/height", 180, json=False),
+    })
+
+def set_nostr_pubkey(npub):
+    _extdata['zaps'] = ExternalData("https://api.nostr.band/v0/stats/profile/"+npub, 300)
+
+def refresh(raise_on_failure=False):
+    refreshed = []
+    failures = []
+    for key, datum in _extdata.items():
+        result = datum.refresh()
+        if result == False:
+            failures.append(key)
+        elif result == True:
+            refreshed.append(key)
+        else:
+            pass # no change
+    if failures:
+        msg = "datastore.refresh() had failures: {}".format(",".join(failures))
+        if raise_on_failure:
+            raise Exception(msg)
+        else:
+            print(msg)
+    return refreshed
+
+
+#
+# functions for getting "raw" values from the _extdata singleton
+#
+
+def list_stale():
+    return [k for k,v in _extdata.items() if v.stale]
+
+def get_height():
+    if "height" in _extdata:
+        return int(_extdata["height"].data)
+
+def get_price(key): # USD, EUR
+    if "prices" in _extdata:
+        return _extdata["prices"].data[key]
+
+def get_fees_dict():
+    if "fees" in _extdata:
+        return _extdata["fees"].data
+
+def get_nostr_zap_count():
+    if "zaps" in _extdata:
+        pubkey = [x for x in _extdata["zaps"].data['stats'].keys()][0]
+        return _extdata["zaps"].data["stats"][pubkey]["zaps_received"]["count"]

--- a/src/orangeClockFunctions/displayBlockMoscowFees.py
+++ b/src/orangeClockFunctions/displayBlockMoscowFees.py
@@ -26,6 +26,7 @@ labelRow3 = 98
 symbolRow1 = "A"
 symbolRow2 = "L"
 symbolRow3 = "F"
+spaceRow3 = 4
 warningIcon = "R"
 secretsSSID = ""
 secretsPASSWORD = ""
@@ -75,16 +76,40 @@ def getLastBlock():
 
 
 def getMempoolFeesString():
+    def build_fees_string(mempoolFees, labels=True, halfHourFee=True):
+        key_label_tuples = (
+            ("hourFee", "L"),
+            ("halfHourFee","M"),
+            ("fastestFee","H")
+        )
+        fees = []
+        for key, label in key_label_tuples:
+            if key == "halfHourFee" and not halfHourFee:
+                continue
+            if labels:
+                fees.append(label + ":" + str(mempoolFees[key]))
+            else:
+                fees.append(str(mempoolFees[key]))
+        separator = " - " if len(fees) == 2 else "  "
+        return separator.join(fees)
+
     mempoolFees = datastore.get_fees_dict()
-    mempoolFeesString = (
-        "L:"
-        + str(mempoolFees["hourFee"])
-        + " M:"
-        + str(mempoolFees["halfHourFee"])
-        + " H:"
-        + str(mempoolFees["fastestFee"])
-    )
-    return mempoolFeesString
+
+    # width_of_screen - fees_icon - fees_space
+    max_width = rowMaxDisplay - wri_iconsSmall.stringlen(symbolRow3) - spaceRow3
+
+    answer = build_fees_string(mempoolFees)
+    if wri_small.stringlen(answer) > max_width:
+        # too big, try w/o medium-priority fees
+        answer = build_fees_string(mempoolFees, halfHourFee=False)
+    if wri_small.stringlen(answer) > max_width:
+        # too big, try w/o "L:", "M:", and "H:" labels
+        answer = build_fees_string(mempoolFees, labels=False)
+    if wri_small.stringlen(answer) > max_width:
+        # too big, try w/o labels and w/o medium-priority fees
+        answer = build_fees_string(mempoolFees, labels=False, halfHourFee=False)
+
+    return answer
 
 
 def getNostrZapCount():
@@ -283,7 +308,7 @@ def main():
                         rowMaxDisplay
                         - Writer.stringlen(wri_small, mempoolFees)
                         + Writer.stringlen(wri_iconsSmall, symbolRow3)
-                        + 4  # spacing
+                        + spaceRow3  # spacing
                     )
                     / 2
                 ),
@@ -297,7 +322,7 @@ def main():
                         rowMaxDisplay
                         - Writer.stringlen(wri_iconsSmall, symbolRow3)
                         - Writer.stringlen(wri_small, mempoolFees)
-                        - 4  # spacing
+                        - spaceRow3  # spacing
                     )
                     / 2
                 ),

--- a/src/orangeClockFunctions/displayBlockMoscowFees.py
+++ b/src/orangeClockFunctions/displayBlockMoscowFees.py
@@ -2,6 +2,7 @@ from color_setup import ssd
 from gui.core.writer import Writer
 from gui.core.nanogui import refresh
 from gui.widgets.label import Label
+from orangeClockFunctions.logging import log_exception
 
 import network
 import time
@@ -178,6 +179,7 @@ def main():
                 symbolRow1 = "A"
                 blockHeight = getLastBlock()    
         except Exception as err:
+            log_exception(err)
             blockHeight = "connection error"
             symbolRow1 = ""
             print("Block: Handling run-time error:", err)
@@ -200,6 +202,7 @@ def main():
                 symbolRow2 = "L"
                 textRow2 = getMoscowTime()        
         except Exception as err:
+            log_exception(err)
             textRow2 = "error"
             symbolRow2 = ""
             print("Moscow: Handling run-time error:", err)
@@ -209,6 +212,7 @@ def main():
             symbolRow3 = "F"
             mempoolFees = getMempoolFeesString()
         except Exception as err:
+            log_exception(err)
             mempoolFees = "connection error"
             symbolRow3 = ""
             print("Fees: Handling run-time error:", err)

--- a/src/orangeClockFunctions/displayBlockMoscowFees.py
+++ b/src/orangeClockFunctions/displayBlockMoscowFees.py
@@ -3,11 +3,10 @@ from gui.core.writer import Writer
 from gui.core.nanogui import refresh
 from gui.widgets.label import Label
 from orangeClockFunctions.logging import log_exception
+from orangeClockFunctions import datastore
 
 import network
 import time
-import urequests
-import json
 import gui.fonts.orangeClockIcons25 as iconsSmall
 import gui.fonts.orangeClockIcons35 as iconsLarge
 import gui.fonts.libreFranklinBold50 as large
@@ -27,11 +26,13 @@ labelRow3 = 98
 symbolRow1 = "A"
 symbolRow2 = "L"
 symbolRow3 = "F"
+warningIcon = "R"
 secretsSSID = ""
 secretsPASSWORD = ""
 dispVersion1 = "bh"  #bh = block height / hal = halving countdown / zap = Nostr zap counter
 dispVersion2 = "mts" #mts = moscow time satsymbol / mts2 = moscow time satusd icon / mt = without satsymbol / fp1 = fiat price [$] / fp2 = fiat price [€]
 npub = ""
+
 
 def connectWIFI():
     global wifi
@@ -58,44 +59,23 @@ def setSecrets(SSID, PASSWORD):
     secretsPASSWORD = PASSWORD
 
 
-def getPrice(currency): # change USD to EUR for price in euro
-    gc.collect()
-    data = urequests.get("https://mempool.space/api/v1/prices")
-    price = data.json()[currency]
-    data.close()
-    return price
-
-
 def getMoscowTime():
-    moscowTime = str(int(100000000 / float(getPrice("USD"))))
-    return moscowTime
+    return str(int(100000000 / float(datastore.get_price("USD"))))
 
 
 def getPriceDisplay(currency):
-    price_str = f"{getPrice(currency):,}"
+    price_str = f"{datastore.get_price(currency):,}"
     if currency == "EUR":
         price_str = price_str.replace(",", ".")
     return price_str
 
 
 def getLastBlock():
-    gc.collect()
-    data = urequests.get("https://mempool.space/api/blocks/tip/height")
-    block = data.text
-    data.close()
-    return block
-
-
-def getMempoolFees():
-    gc.collect()
-    data = urequests.get("https://mempool.space/api/v1/fees/recommended")
-    jsonData = data.json()
-    data.close()
-    return jsonData
+    return str(datastore.get_height())
 
 
 def getMempoolFeesString():
-    mempoolFees = getMempoolFees()
+    mempoolFees = datastore.get_fees_dict()
     mempoolFeesString = (
         "L:"
         + str(mempoolFees["hourFee"])
@@ -107,16 +87,12 @@ def getMempoolFeesString():
     return mempoolFeesString
 
 
-def getNostrZapCount(nPub):
-    gc.collect()
-    data = urequests.get("https://api.nostr.band/v0/stats/profile/"+nPub)
-    jsonData = str(data.json()["stats"][str(data.json())[12:76]]["zaps_received"]["count"])
-    data.close()
-    return jsonData
+def getNostrZapCount():
+    return str(datastore.get_nostr_zap_count())
 
 
 def getNextHalving():
-    return str(210000 * (math.trunc(int(getLastBlock()) / 210000) + 1) - int(getLastBlock()))
+    return str(210000 - datastore.get_height() % 210000)
 
 
 def displayInit():
@@ -132,10 +108,13 @@ def displayInit():
 
 
 def debugConsoleOutput(id):
-    print("===============debug id= " + id + "===============")
-    print("memory use: ", gc.mem_alloc() / 1024, "KiB")
+    mem_alloc = gc.mem_alloc()
+    print("=============== debug id=" + id + " ===============")
+    print("memory used: ", mem_alloc / 1024, "KiB")
     print("memory free: ", gc.mem_free() / 1024, "KiB")
-    print("===============end debug===============")
+    gc.collect()
+    print("gc.collect() freed additional:", (mem_alloc - gc.mem_alloc()) / 1024, "KiB")
+    print("=============== end debug ===============")
 
 
 def main():
@@ -151,6 +130,11 @@ def main():
     i = 1
     connectWIFI()
     displayInit()
+
+    datastore.initialize()
+    if npub:
+        datastore.set_nostr_pubkey(npub)
+
     while True:
         debugConsoleOutput("2")
         if issue:
@@ -169,9 +153,20 @@ def main():
             refresh(ssd, True)
             time.sleep(5)
         try:
+            # alternatively: can avoid using raise_on_falure paramater
+            # and instead call datastore.list_stale() for a list of stale data.
+            new_data = datastore.refresh(raise_on_failure=True)
+            if new_data:
+                print("datastore.refresh() had updates: {}".format(",".join(new_data)))
+        except Exception as err:
+            log_exception(err)
+            debugConsoleOutput("datastore.refresh() failure")
+            print(err)
+            issue = True
+        try:
             if dispVersion1 == "zap":
                 symbolRow1 = "I"
-                blockHeight = getNostrZapCount(npub)
+                blockHeight = getNostrZapCount()
             elif dispVersion1 == "hal":
                 symbolRow1 = "H"
                 blockHeight = getNextHalving()
@@ -219,7 +214,11 @@ def main():
             debugConsoleOutput("5")
             issue = True
 
-        labels = [
+        labels = []
+        if issue:
+            # warning-icon in upper-left corner to indicate error(s)
+            labels.append(Label(wri_iconsSmall, 0, 0, warningIcon))
+        labels += [
             Label(
                 wri_small,
                 labelRow1,
@@ -311,7 +310,6 @@ def main():
         ssd.sleep()
         if not issue:
             time.sleep(600)  # 600 normal
-
         else:
             wifi.disconnect()
             debugConsoleOutput("6")

--- a/src/orangeClockFunctions/logging.py
+++ b/src/orangeClockFunctions/logging.py
@@ -1,0 +1,10 @@
+import uio
+import usys
+from phew import logging
+
+def log_exception(exception):
+    tmp_string = uio.StringIO()
+    usys.print_exception(exception, tmp_string)
+    logging.exception("> {}".format(
+        tmp_string.getvalue().replace("\n", "\\n")
+    ))


### PR DESCRIPTION
DRAFT

replaces #57
replaces #56
replaces #61

This pr merges pr #57, pr #56, and pr #61 on top of "main" at commit 9d71417:
* If this will be merged, then it supersedes all-three of those prs (thus all can be closed at that time)
* this one adds 
  1) importing of orangeClockFunctions.logging's log_exception() function to datastore and 
  2) two more calls to log_exception(err) for one exception caught within datastore and a similar one caught in displayBlockMoscowFees.
  3) a fix for high-fees moments where 3 fees values exceed the screen dimensions and raise an uncaught exception.

I will run this branch on my own OrangeClock for a few days before changing this pr from draft to ready-for-review.