### PR TITLE
While fees are high, less info will be displayed

### DIFF
--- a/src/orangeClockFunctions/displayBlockMoscowFees.py
+++ b/src/orangeClockFunctions/displayBlockMoscowFees.py
@@ -26,6 +26,7 @@ labelRow3 = 98
 symbolRow1 = "A"
 symbolRow2 = "L"
 symbolRow3 = "F"
+spaceRow3 = 4
 secretsSSID = ""
 secretsPASSWORD = ""
 dispVersion1 = "bh"  #bh = block height / hal = halving countdown / zap = Nostr zap counter
@@ -108,20 +109,23 @@ def getMempoolFeesString():
                 fees.append(label + ":" + str(mempoolFees[key]))
             else:
                 fees.append(str(mempoolFees[key]))
-        return " ".join(fees)
+        separator = " - " if len(fees) == 2 else "  "
+        return separator.join(fees)
 
     mempoolFees = getMempoolFees()
-    max_string_length = 16
+
+    # width_of_screen - fees_icon - fees_space
+    max_width = rowMaxDisplay - wri_iconsSmall.stringlen(symbolRow3) - spaceRow3
 
     answer = build_fees_string(mempoolFees)
-    if len(answer) > max_string_length:
+    if wri_small.stringlen(answer) > max_width:
+        # too big, try w/o medium-priority fees
+        answer = build_fees_string(mempoolFees, halfHourFee=False)
+    if wri_small.stringlen(answer) > max_width:
         # too big, try w/o "L:", "M:", and "H:" labels
         answer = build_fees_string(mempoolFees, labels=False)
-    if len(answer) > max_string_length:
-        # still too big, try w/o medium-priority fees
-        answer = build_fees_string(mempoolFees, halfHourFee=False)
-    if len(answer) > max_string_length:
-        # still too big, try w/o labels and w/o medium-priority fees
+    if wri_small.stringlen(answer) > max_width:
+        # too big, try w/o labels and w/o medium-priority fees
         answer = build_fees_string(mempoolFees, labels=False, halfHourFee=False)
 
     return answer
@@ -301,7 +305,7 @@ def main():
                         rowMaxDisplay
                         - Writer.stringlen(wri_small, mempoolFees)
                         + Writer.stringlen(wri_iconsSmall, symbolRow3)
-                        + 4  # spacing
+                        + spaceRow3  # spacing
                     )
                     / 2
                 ),
@@ -315,7 +319,7 @@ def main():
                         rowMaxDisplay
                         - Writer.stringlen(wri_iconsSmall, symbolRow3)
                         - Writer.stringlen(wri_small, mempoolFees)
-                        - 4  # spacing
+                        - spaceRow3  # spacing
                     )
                     / 2
                 ),

--- a/src/orangeClockFunctions/displayBlockMoscowFees.py
+++ b/src/orangeClockFunctions/displayBlockMoscowFees.py
@@ -94,16 +94,37 @@ def getMempoolFees():
 
 
 def getMempoolFeesString():
+    def build_fees_string(mempoolFees, labels=True, halfHourFee=True):
+        key_label_tuples = (
+            ("hourFee", "L"),
+            ("halfHourFee","M"),
+            ("fastestFee","H")
+        )
+        fees = []
+        for key, label in key_label_tuples:
+            if key == "halfHourFee" and not halfHourFee:
+                continue
+            if labels:
+                fees.append(label + ":" + str(mempoolFees[key]))
+            else:
+                fees.append(str(mempoolFees[key]))
+        return " ".join(fees)
+
     mempoolFees = getMempoolFees()
-    mempoolFeesString = (
-        "L:"
-        + str(mempoolFees["hourFee"])
-        + " M:"
-        + str(mempoolFees["halfHourFee"])
-        + " H:"
-        + str(mempoolFees["fastestFee"])
-    )
-    return mempoolFeesString
+    max_string_length = 16
+
+    answer = build_fees_string(mempoolFees)
+    if len(answer) > max_string_length:
+        # too big, try w/o "L:", "M:", and "H:" labels
+        answer = build_fees_string(mempoolFees, labels=False)
+    if len(answer) > max_string_length:
+        # still too big, try w/o medium-priority fees
+        answer = build_fees_string(mempoolFees, halfHourFee=False)
+    if len(answer) > max_string_length:
+        # still too big, try w/o labels and w/o medium-priority fees
+        answer = build_fees_string(mempoolFees, labels=False, halfHourFee=False)
+
+    return answer
 
 
 def getNostrZapCount(nPub):


### PR DESCRIPTION
DRAFT

In order to survive e-paper hat display over-runs during high-fees moments:

This pr changes a single function, getMempoolFeesString(), to display less info:
* by calculating how many pixels are available on screen given fees-icon and a fees-spacer
* when there is plenty of room, 3 fees with two-spaces between each,  ie: "L:9  M:23  H:67" fits
* removing med-priority fees and separating the range w/ " - " when too big, ie: "L:78901 - H:123456" fits
* if above strategy doesn't work, an unlikely-to-work strategy of 3 fees values w/o "L:/M:/H:" labels
* removing labels and med-priority fees when still too big, ie: "9012345 - 12345678" fits

With current 25-pixel-high icon fonts, the max width of the rest of the line is 265px (icon takes 27 + 4px spacer).

As well as adding a new module-level variable "spaceRow3" used to hard-code number of pixels between fees icon and fees text... then uses that in the above function as well as the definiton of "labels" which draws to the screen